### PR TITLE
[#8] http2 push example for the appengine java runtime

### DIFF
--- a/examples/java/.gitignore
+++ b/examples/java/.gitignore
@@ -1,0 +1,26 @@
+## https://github.com/github/gitignore/blob/master/Java.gitignore
+*.class
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.ear
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+## https://github.com/github/gitignore/blob/master/Maven.gitignore
+target/
+.idea/
+*.iml
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties

--- a/examples/java/pom.xml
+++ b/examples/java/pom.xml
@@ -1,0 +1,114 @@
+<!--
+ Copyright 2016 Google Inc. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>war</packaging>
+    <version>1.0</version>
+
+    <groupId>com.google.appengine.demos</groupId>
+    <artifactId>http2push-gae</artifactId>
+
+    <properties>
+      <appengine.app.version>1</appengine.app.version>
+      <appengine.target.version>1.9.38</appengine.target.version>
+      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <!-- Compile/runtime dependencies -->
+        <dependency>
+            <groupId>com.google.appengine</groupId>
+            <artifactId>appengine-api-1.0-sdk</artifactId>
+            <version>${appengine.target.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+            <version>2.5</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20160212</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>19.0</version>
+        </dependency>
+
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.10</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.9.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.appengine</groupId>
+            <artifactId>appengine-testing</artifactId>
+            <version>${appengine.target.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.appengine</groupId>
+            <artifactId>appengine-api-stubs</artifactId>
+            <version>${appengine.target.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+      
+    <build>
+        <outputDirectory>target/${project.artifactId}/WEB-INF/classes</outputDirectory> 
+                                   
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>2.3</version>
+                <configuration>
+                    <archiveClasses>true</archiveClasses>
+                    <webResources>
+                        <!-- in order to interpolate version from pom into appengine-web.xml -->
+                        <resource>
+                            <directory>${basedir}/src/main/webapp/WEB-INF</directory>
+                            <filtering>true</filtering>
+                            <targetPath>WEB-INF</targetPath>
+                        </resource>
+                    </webResources>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>com.google.appengine</groupId>
+                <artifactId>appengine-maven-plugin</artifactId>
+                <version>${appengine.target.version}</version>
+                <configuration>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/examples/java/src/main/java/myapp/IndexDispatcherFilter.java
+++ b/examples/java/src/main/java/myapp/IndexDispatcherFilter.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package myapp;
+
+import com.google.common.base.Charsets;
+import com.google.common.base.Strings;
+import com.google.common.io.CharStreams;
+import com.google.common.io.Closeables;
+import org.json.JSONObject;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+public class IndexDispatcherFilter implements Filter {
+
+    private String resourcesToPush;
+
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException,
+            ServletException {
+        String nopush = request.getParameter("nopush");
+        if (!Strings.isNullOrEmpty(resourcesToPush) && null == nopush) {
+            HttpServletResponse httpResponse = (HttpServletResponse) response;
+            httpResponse.addHeader("Link", resourcesToPush);
+        }
+        RequestDispatcher rd = request.getRequestDispatcher("/index.html");
+        rd.forward(request, response);
+    }
+
+    public void init(FilterConfig filterConfig) throws ServletException {
+        InputStream is = filterConfig.getServletContext().getResourceAsStream("/push_manifest.json");
+        try {
+            String rawJson = CharStreams.toString(new InputStreamReader(is, Charsets.UTF_8));
+            JSONObject pushManifest = new JSONObject(rawJson);
+            StringBuilder linkValue = new StringBuilder();
+            for(String asset: pushManifest.keySet()) {
+                String assetUrl = asset;
+                String type = pushManifest.getJSONObject(assetUrl).getString("type");
+                linkValue.append("<");
+                linkValue.append(assetUrl);
+                linkValue.append(">; rel=preload; as=");
+                linkValue.append(type);
+                linkValue.append(",");
+            }
+            resourcesToPush = linkValue.toString();
+        } catch (IOException e) {
+            throw new ServletException(e);
+        } finally {
+            Closeables.closeQuietly(is);
+        }
+    }
+
+    public void destroy() {  }
+
+}

--- a/examples/java/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/examples/java/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
+    <application>your-project-id-here</application>
+    <version>1</version>
+    <threadsafe>true</threadsafe>
+
+	<resource-files>
+	  <include path="/push_manifest.json" />
+      <include path="/index.html" />
+	</resource-files>
+
+	<static-files>
+	  <include path="/static.html">
+		  <http-header name="Link" value="&lt;/js/app.js&gt;; rel=preload; as=script, &lt;/css/app.css&gt;; rel=preload; as=style" />
+	  </include>	
+	  <include path="/css/**" />
+	  <include path="/js/**" />
+	</static-files>&lt;
+
+  	<ssl-enabled>true</ssl-enabled>
+
+</appengine-web-app>

--- a/examples/java/src/main/webapp/WEB-INF/logging.properties
+++ b/examples/java/src/main/webapp/WEB-INF/logging.properties
@@ -1,0 +1,13 @@
+# A default java.util.logging configuration.
+# (All App Engine logging is through java.util.logging by default).
+#
+# To use this configuration, copy it into your application's WEB-INF
+# folder and add the following to your appengine-web.xml:
+# 
+# <system-properties>
+#   <property name="java.util.logging.config.file" value="WEB-INF/logging.properties"/>
+# </system-properties>
+#
+
+# Set the default logging level for all loggers to WARNING
+.level = WARNING

--- a/examples/java/src/main/webapp/WEB-INF/web.xml
+++ b/examples/java/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE web-app PUBLIC
+ "-//Oracle Corporation//DTD Web Application 2.3//EN"
+ "http://java.sun.com/dtd/web-app_2_3.dtd">
+
+<web-app xmlns="http://java.sun.com/xml/ns/javaee" version="2.5">
+
+    <filter>
+        <filter-name>indexDispatcherFilter</filter-name>
+        <filter-class>myapp.IndexDispatcherFilter</filter-class>
+    </filter>
+    <filter-mapping>
+        <filter-name>indexDispatcherFilter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+
+
+</web-app>

--- a/examples/java/src/main/webapp/css/app.css
+++ b/examples/java/src/main/webapp/css/app.css
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+body {
+  font-family: "Roboto", sans-serif;
+  font-size: 16px;
+  font-weight: 300;
+  margin: 3em;
+  line-height: 2;
+  color: #757575;
+}
+
+h2, h3 {
+  font-weight: 400;
+}

--- a/examples/java/src/main/webapp/index.html
+++ b/examples/java/src/main/webapp/index.html
@@ -1,0 +1,33 @@
+<!--
+Copyright 2015 Google Inc. All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+  <title>HTTP 2.0 push on App Engine - example</title>
+  <link rel="stylesheet" href="/css/app.css">
+</head>
+<body>
+
+<h3>The static resources on this page (app.js and app.css) have been server pushed!</h3>
+<p>Verify by opening <code>chrome://net-internals</code>, drilling into HTTP2 in the dropdown, and refreshing the page.</p>
+
+<p><b>Note</b>: resources won't be pushed if you're running this page locally using the dev server.
+The app needs to be deployed to App Engine.</p>
+
+<script src="/js/app.js"></script>
+</body>
+</html>

--- a/examples/java/src/main/webapp/js/app.js
+++ b/examples/java/src/main/webapp/js/app.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+console.log('I was http2 pushed!');

--- a/examples/java/src/main/webapp/push_manifest.json
+++ b/examples/java/src/main/webapp/push_manifest.json
@@ -1,0 +1,10 @@
+{
+  "/css/app.css": {
+    "weight": 1,
+    "type": "style"
+  },
+  "/js/app.js": {
+    "weight": 1,
+    "type": "script"
+  }
+}

--- a/examples/java/src/main/webapp/static.html
+++ b/examples/java/src/main/webapp/static.html
@@ -1,0 +1,35 @@
+<!--
+Copyright 2015 Google Inc. All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+  <title>HTTP 2.0 push on App Engine - static handler example</title>
+  <link rel="stylesheet" href="/css/app.css">
+</head>
+<body>
+
+<h2>Static handler demo</h2>
+
+<h3>The static resources on this page (app.js and app.css) have been server pushed!</h3>
+<p>Verify by opening <code>chrome://net-internals</code>, drilling into HTTP2 in the dropdown, and refreshing the page.</p>
+
+<p><b>Note</b>: resources won't be pushed if you're running this page locally using the dev server.
+The app needs to be deployed to App Engine.</p>
+
+<script src="/js/app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Solves #8:

Simple `IndexDispatcherFilter` which parses `push_manifest.json` at application startup and populates the response header with the push entries before forwading to index.html.


